### PR TITLE
feat: allow any and all executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +233,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,9 +309,12 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -646,6 +682,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +860,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -982,6 +1068,7 @@ dependencies = [
  "async-trait",
  "eyre",
  "quote",
+ "serial_test",
  "sqlx",
  "syn",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ sqlx = { version = "0.6", default-features = false, features = ["runtime-actix-r
 
 [dev-dependencies]
 tokio = { version = "1.19", features= ["rt-multi-thread",  "macros"] }
+serial_test = "0.9.0"
 sqlx = { version = "0.6", default-features = false, features = ["runtime-actix-rustls", "macros", "sqlite", "postgres"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ pub fn derive_update_from_struct_psql(input: TokenStream) -> TokenStream {
             pub fn update_query_string(&self, table: &str, where_field: &str) -> String
             {
 
-                let fields_for_update = #columns.trim().split(", ").collect::<Vec<&str>>();
+                let fields_for_update = #columns.trim().split(",").map(|s|s.trim()).collect::<Vec<&str>>();
                  let where_field_tuple = fields_for_update.iter().enumerate().find(|(i,&item)| item == where_field).expect("Where field does not exist as field on struc");
                 let where_clause = format!("WHERE {} = ${}", where_field_tuple.1, where_field_tuple.0 + 1);
 

--- a/tests/psgl_test.rs
+++ b/tests/psgl_test.rs
@@ -83,8 +83,8 @@ async fn test_update_string() {
         id: 1,
         name: "Skoda".into(),
     };
-    let upd_str = car_skoda.update_query_string("cars", "id");
-    let expected_str = "UPDATE cars SET name = $2 WHERE id = $1  returning *";
+    let upd_str = car_skoda.update_query_string("cars", vec!["id"]);
+    let expected_str = "UPDATE cars SET name = $2 WHERE id = $1 returning *";
 
     assert_eq!(expected_str, upd_str)
 }
@@ -134,7 +134,7 @@ async fn test_macro_update() {
     };
 
     updated_car
-        .update(&pool, "cars", "id")
+        .update(&pool, "cars", vec!["id"])
         .await
         .expect("Not possible to update in db");
 

--- a/tests/psgl_test.rs
+++ b/tests/psgl_test.rs
@@ -1,10 +1,12 @@
+use serial_test::serial;
+
 // extern crate we're testing, same as any other code will do.
 //extern crate gmacro;
 
 // use sqlx::PgQuery;
 
 // #[derive(Default, Debug, sqlx::FromRow)]
-#[derive(Default, Debug, std::cmp::PartialEq, sqlx::FromRow)]
+#[derive(Default, Debug, std::cmp::PartialEq, sqlx::FromRow, sqlxinsert::PgUpdate)]
 struct Car {
     pub id: i32,
     pub name: String,
@@ -25,6 +27,7 @@ impl CreateCar {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_macro_insert() {
     let car_skoda = CreateCar::new("Skoda");
     let car_tesla = CreateCar::new("Tesla");
@@ -72,4 +75,74 @@ async fn test_macro_insert() {
     assert_eq!(cars[0].id, 1);
     assert_eq!(cars[1].name, "Tesla");
     assert_eq!(cars[1].id, 2);
+}
+
+#[tokio::test]
+async fn test_update_string() {
+    let car_skoda = Car {
+        id: 1,
+        name: "Skoda".into(),
+    };
+    let upd_str = car_skoda.update_query_string("cars", "id");
+    let expected_str = "UPDATE cars SET name = $2 WHERE id = $1  returning *";
+
+    assert_eq!(expected_str, upd_str)
+}
+
+#[tokio::test]
+#[serial]
+async fn test_macro_update() {
+    let car_skoda = CreateCar::new("Skoda");
+
+    let url = "postgres://user:pass@localhost:5444/test_db";
+
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(std::time::Duration::from_secs(30))
+        .connect(url)
+        .await
+        .expect("Not possible to create pool");
+
+    // Reset database
+    let drop_table = "DROP TABLE IF EXISTS cars";
+    sqlx::query(drop_table).execute(&pool).await.unwrap();
+
+    let create_table = "create table cars (
+        id SERIAL PRIMARY KEY,
+        name TEXT NOT NULL,
+        color TEXT
+    )";
+
+    sqlx::query(create_table).execute(&pool).await.unwrap();
+
+    // Fill data
+    car_skoda
+        .insert(&pool, "cars")
+        .await
+        .expect("Not possible to insert into dabase");
+
+    let car = sqlx::query_as::<_, Car>("SELECT * FROM cars WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .expect("Not possible to fetch");
+
+    assert_eq!(car.name, "Skoda");
+    assert_eq!(car.id, 1);
+
+    let updated_car = Car {
+        name: String::from("Skoda Octavia"),
+        ..car
+    };
+
+    updated_car
+        .update(&pool, "cars", "id")
+        .await
+        .expect("Not possible to update in db");
+
+    let new_car = sqlx::query_as::<_, Car>("SELECT * FROM cars WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .expect("Not possible to fetch");
+
+    assert_eq!(new_car.name, "Skoda Octavia");
+    assert_eq!(new_car.id, 1);
 }

--- a/tests/psgl_test.rs
+++ b/tests/psgl_test.rs
@@ -50,17 +50,17 @@ async fn test_macro_insert() {
     sqlx::query(create_table).execute(&pool).await.unwrap();
 
     // Fill data
-    let car_skoda_res = car_skoda
-        .insert::<Car>(&pool, "cars")
+    car_skoda
+        .insert(&pool, "cars")
         .await
         .expect("Not possible to insert into dabase");
-    assert_eq!(car_skoda_res.name, car_skoda.name);
+    // assert_eq!(car_skoda_res.name, car_skoda.name);
 
-    let car_tesla_res = car_tesla
-        .insert::<Car>(&pool, "cars")
+    car_tesla
+        .insert(&pool, "cars")
         .await
         .expect("Not possible to insert into dabase");
-    assert_eq!(car_tesla_res.name, car_tesla.name);
+    // assert_eq!(car_tesla_res.name, car_tesla.name);
 
     let cars = sqlx::query_as::<_, Car>("SELECT * FROM cars")
         .fetch_all(&pool)


### PR DESCRIPTION
Hey there @fbucek!

Feel free to toss this out / suggest changes.
I was recently finding a need for this at work, and had to fork in order for it to fit the needs of our project.

There were a couple of major changes, happy to open a PR with any combination of them instead of this PR.

- 1. Removed eyre and rely on sqlx result types where possible -- Consuming libaries/binaries may not want to opt into the error library just to use this, whereas they are already using sqlx
- 2. Replaced Pool with Executor -- This allows you to use the insert with DB Transactions, which is sometimes desired behavior when working with insert/update.
- 3. Remove return of Insert -- Unfortunately this was necessary in order to allow transactions (in my case). Maybe there could be two inserts; one which returns data and one which does not
- 4. Added the ability to update -- I'm finding it useful but it may not be what people want 🤷 

Like I said, was just trying to accelerate progress on a work project. If you want any of it I can spend a bit of my own time tidying it up / making any changes you want etc.

I've tested it my project and it has worked fine.
