### PR TITLE
add feature flags: `sqlite` and `postgres`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,13 @@ eyre = "0.6"
 quote = "1.0"
 syn = "2.0"
 async-trait = "0.1"
-sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "sqlite", "postgres"] }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio"] }
+
+[features]
+default = ["sqlite", "postgres"]
+sqlite = [ "sqlx/sqlite" ]
+postgres = [ "sqlx/postgres" ]
+
 
 [dev-dependencies]
 tokio = { version = "1.19", features= ["rt-multi-thread",  "macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use crate::common::dollar_values;
 /// # }
 /// ```
 ///
+#[cfg(feature = "sqlite")]
 #[proc_macro_derive(SqliteInsert)]
 pub fn derive_from_struct_sqlite(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -159,6 +160,7 @@ pub fn derive_from_struct_sqlite(input: TokenStream) -> TokenStream {
 /// # }
 /// ```
 ///
+#[cfg(feature = "postgres")]
 #[proc_macro_derive(PgInsert)]
 pub fn derive_from_struct_psql(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/tests/psgl_test.rs
+++ b/tests/psgl_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "postgres")]
 // extern crate we're testing, same as any other code will do.
 //extern crate gmacro;
 

--- a/tests/raw_psql_test.rs
+++ b/tests/raw_psql_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "postgres")]
 // #[derive(Default, Debug, sqlx::FromRow)]
 #[derive(Default, Debug, sqlx::FromRow)]
 struct Car {

--- a/tests/raw_psql_test_generic.rs
+++ b/tests/raw_psql_test_generic.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "postgres")]
 // #[derive(Default, Debug, sqlx::FromRow)]
 #[derive(Default, Debug, sqlx::FromRow)]
 struct Car {

--- a/tests/raw_sqlite_test.rs
+++ b/tests/raw_sqlite_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sqlite")]
+
 #[derive(Default, Debug, sqlx::FromRow)]
 struct Car {
     pub car_id: i32,

--- a/tests/raw_sqlite_test_generic.rs
+++ b/tests/raw_sqlite_test_generic.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "sqlite")]
 // #[derive(Default, Debug, sqlx::FromRow)]
 #[derive(Default, Debug, sqlx::FromRow)]
 struct Car {

--- a/tests/sqlite_test.rs
+++ b/tests/sqlite_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "sqlite")]
 // extern crate we're testing, same as any other code will do.
 //extern crate gmacro;
 


### PR DESCRIPTION
Enables sqlxinsert to be used without a dependency on sqlite and postgres. Which is especially useful for users only interested in the sqlite part or the postgres part. Both of the features are enabled by default and therefore are not breaking any working code.

This was tested only for sqlite. Because of me not having a postgres instance avaiable.
```sh
cargo test --no-default-features --features sqlite
```

The new features are names `sqlite` and `postgres` following the naming scheme of sqlx.